### PR TITLE
Fix: Coverage Comment Scope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
           set +o pipefail
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
+        # no need to comment on merging to main; only need for pr
+        # it will fail anyway because of branch protection rejects commit comments
+        if: github.event_name == 'pull_request'
         with:
           title: Coverage for ${{ matrix.test-type }} tests for Python ${{ matrix.python-version }}
           create-new-comment: true


### PR DESCRIPTION
Make sure coverage comment is only triggered when doing PR, not when merging to main.
The latter will fail anyways because (I think) making commit comments will get rejected due to main branch protection. Probably can be fixed but no point fixing it. We only need coverage stats for PR and we will be moving to CodeCov soon anyway.