### PR TITLE
Feat: Email Preview and Editor

### DIFF
--- a/server/forms.py
+++ b/server/forms.py
@@ -1,9 +1,8 @@
-from os import abort
 import re
 
 from flask_wtf import FlaskForm
 from wtforms import BooleanField, SelectMultipleField, StringField, SubmitField, \
-    TextAreaField, widgets
+    TextAreaField, widgets, ValidationError
 from wtforms.validators import Email, InputRequired, URL
 
 from server.controllers import exam_regex
@@ -73,12 +72,23 @@ class AssignForm(FlaskForm):
     submit = SubmitField('assign')
 
 
+def validate_email_list(form, field):
+    email_list = field.data.split(',')
+    for email in email_list:
+        email = email.strip()
+        if not Email()(form, field):
+            print(f'Invalid email address: {email}')
+            raise ValidationError(f'Invalid email address: {email}')
+
+
 class EmailForm(FlaskForm):
     from_addr = StringField('from_addr', [Email(), InputRequired()])
-    signature = StringField('signature', [InputRequired()])
-    additional_info = TextAreaField('additional_info')
-    override_subject = StringField('override_subject')
-    override_to_addr = StringField('override_to_addr')
+    to_addr = StringField('to_addr', [InputRequired()])
+    cc_addr = StringField('cc_addr', [])
+    bcc_addr = StringField('bcc_addr', [])
+    subject = StringField('subject', [InputRequired()])
+    body = TextAreaField('body', [InputRequired()])
+    body_html = BooleanField('body_html', default=True)
     submit = SubmitField('send')
 
 

--- a/server/services/email/__init__.py
+++ b/server/services/email/__init__.py
@@ -1,5 +1,5 @@
 from server import app
-from server.models import Student, db, Exam, SeatAssignment, Offering
+from server.models import db
 from server.services.email.smtp import SMTPConfig, send_email
 import server.services.email.templates as templates
 from server.typings.enum import EmailTemplate
@@ -14,68 +14,42 @@ _email_config = SMTPConfig(
 )
 
 
-def email_students(exam: Exam, form):
-    ASSIGNMENT_PER_PAGE = 500
-    page_number = 1
-
-    email_success: set[Student] = set()
-    email_failure: set[Student] = set()
-
-    while True:
-        assignments = exam.get_assignments(
-            emailed=False,
-            limit=ASSIGNMENT_PER_PAGE,
-            offset=(page_number - 1) * ASSIGNMENT_PER_PAGE
-        )
-        if not assignments:
-            break
-
-        for assignment in assignments:
-            result = _email_single_assignment(exam.offering, exam, assignment, form)
-            if result[0]:
-                email_success.add(assignment.student)
-                assignment.emailed = True
-            else:
-                email_failure.add(assignment.student)
-
-        db.session.commit()
-
-    return email_success, email_failure
-
-
-def email_student(exam: Exam, student_db_id: int, form):
-    assignment: SeatAssignment = Student.query.get(student_db_id).assignment
-    if assignment is None:
-        return (False, "Student has no assignment.")
-    result = _email_single_assignment(exam.offering, exam, assignment, form)
-    if result[0]:
-        assignment.emailed = True
-        db.session.commit()
-    return result
-
-
-def _email_single_assignment(offering: Offering, exam: Exam, assignment: SeatAssignment, form):
-    seat_path = url_for('student_single_seat', seat_id=assignment.seat.id)
-    seat_absolute_path = os.path.join(app.config.get('SERVER_BASE_URL'), seat_path)
-
-    student_email = \
-        templates.get_email(EmailTemplate.ASSIGNMENT_INFORM_EMAIL,
-                            {"EXAM": exam.display_name},
-                            {"NAME": assignment.student.first_name,
-                                "COURSE": offering.name,
-                                "EXAM": exam.display_name,
-                                "ROOM": assignment.seat.room.display_name,
-                                "SEAT": assignment.seat.name,
-                                "URL": seat_absolute_path,
-                                "ADDITIONAL_INFO": form.additional_info.data,
-                                "SIGNATURE": form.signature.data})
-
-    effective_to_addr = form.override_to_addr.data or assignment.student.email
-    effective_subject = form.override_subject.data or student_email.subject
-
-    return send_email(smtp=_email_config,
-                      from_addr=form.from_addr.data,
-                      to_addr=effective_to_addr,
-                      subject=effective_subject,
-                      body=student_email.body,
-                      body_html=student_email.body if student_email.body_html else None)
+def email_about_assignment(exam, form, to_addrs):
+    if isinstance(to_addrs, str):
+        to_addrs = to_addrs.strip().split(',')
+    if not to_addrs:
+        return set(), set()
+    success_addrs, failure_addrs = set(), set()
+    all_students = {s.email: s for s in exam.students}
+    for to_addr in to_addrs:
+        student = all_students.get(to_addr, None)
+        if not student or not student.assignment:
+            failure_addrs.add(to_addr)
+            continue
+        assignment = student.assignment
+        seat_path = url_for('student_single_seat', seat_id=assignment.seat.id)
+        seat_absolute_path = os.path.join(app.config.get('SERVER_BASE_URL'), seat_path)
+        subject = templates.make_substitutions(form.subject.data, {"EXAM": exam.display_name})
+        body = templates.make_substitutions(form.body.data,
+                                            {"NAME": assignment.student.first_name,
+                                             "COURSE": exam.offering.name,
+                                             "EXAM": exam.display_name,
+                                             "ROOM": assignment.seat.room.display_name,
+                                             "SEAT": assignment.seat.name,
+                                             "URL": seat_absolute_path})
+        success, payload = send_email(
+            smtp=_email_config,
+            from_addr=form.from_addr.data,
+            to_addr=to_addr,
+            subject=subject,
+            body=body,
+            body_html=body if form.body_html else None,
+            cc_addr=form.cc_addr.data,
+            bcc_addr=form.bcc_addr.data)
+        if success:
+            success_addrs.add(to_addr)
+            assignment.emailed = True
+        else:
+            failure_addrs.add(to_addr)
+    db.session.commit()
+    return success_addrs, failure_addrs

--- a/server/services/email/smtp.py
+++ b/server/services/email/smtp.py
@@ -19,13 +19,20 @@ class SMTPConfig:
                 f'use_auth={self.use_auth})')
 
 
-def send_email(*, smtp: SMTPConfig, from_addr, to_addr, subject, body, body_html=None):
+def send_email(*, smtp: SMTPConfig, from_addr, to_addr, subject, body, body_html=None, bcc_addr=None, cc_addr=None):
     msg = EmailMessage()
     msg['From'] = from_addr
     msg['To'] = to_addr
     msg['Subject'] = subject
+    if bcc_addr:
+        if isinstance(bcc_addr, str):
+            bcc_addr = bcc_addr.split(',')
+        msg['Bcc'] = bcc_addr
+    if cc_addr:
+        if isinstance(cc_addr, str):
+            cc_addr = cc_addr.split(',')
+        msg['Cc'] = cc_addr
     msg.set_content(body)
-
     if body_html:
         msg.add_alternative(body_html, subtype='html')
 

--- a/server/services/email/smtp.py
+++ b/server/services/email/smtp.py
@@ -1,4 +1,4 @@
-from smtplib import SMTP
+from smtplib import SMTP, SMTPException
 from email.message import EmailMessage
 
 
@@ -12,7 +12,11 @@ class SMTPConfig:
         self.use_auth = use_auth
 
     def __repr__(self) -> str:
-        return f'SMTPConfig(smtp_server={self.smtp_server}, smtp_port={self.smtp_port}, username={self.username}, use_tls={self.use_tls}, use_auth={self.use_auth})'  # noqa
+        return (f'SMTPConfig(smtp_server={self.smtp_server}, '
+                f'smtp_port={self.smtp_port}, '
+                f'username={self.username}, '
+                f'use_tls={self.use_tls}, '
+                f'use_auth={self.use_auth})')
 
 
 def send_email(*, smtp: SMTPConfig, from_addr, to_addr, subject, body, body_html=None):
@@ -36,5 +40,7 @@ def send_email(*, smtp: SMTPConfig, from_addr, to_addr, subject, body, body_html
         server.send_message(msg)
         server.quit()
         return (True, None)
+    except SMTPException as e:
+        return (False, f"SMTP error occurred when sending email: {e.message}\n Config: \n{smtp}")
     except Exception as e:
         return (False, f"Error sending email: {e.message}\n Config: \n{smtp}")

--- a/server/services/email/templates/__init__.py
+++ b/server/services/email/templates/__init__.py
@@ -10,31 +10,38 @@ class EmailContent:
         self.body = body
         self.body_html = body_html
 
+    def apply_substitutions(self, subject_substitutions: dict[str, str], body_substitutions: dict[str, str]):
+        if subject_substitutions:
+            self.subject = make_substitutions(self.subject, subject_substitutions)
+        if body_substitutions:
+            self.body = make_substitutions(self.body, body_substitutions)
+
     def __repr__(self) -> str:
         return f'EmailContent(subject={self.subject}, body={self.body}, body_type={self.body_html})'
 
 
 def get_email(
         template: EmailTemplate,
-        subject_substitutions: dict[str, str],
-        body_substitutions: dict[str, str]
+        subject_substitutions: dict[str, str] = None,
+        body_substitutions: dict[str, str] = None
 ) -> EmailContent:
     # template.value is the file name for email metadata (json)
     # let us read it that first. The file sits in the same path as this file.
     email_metadata = None
     with open(os.path.join(os.path.dirname(__file__), template.value + ".json")) as f:
         email_metadata = json.load(f)
-    subject = _make_substitutions(email_metadata['subject'], subject_substitutions)
+    subject = email_metadata['subject']
     body_html = email_metadata['body_html']
     body_path = os.path.join(os.path.dirname(__file__), email_metadata['body_path'])
     body = None
     with open(body_path) as f:
-        body = _make_substitutions(f.read(), body_substitutions)
+        body = f.read()
     content = EmailContent(subject, body, re.match('[Tt]rue', body_html) is not None)
+    content.apply_substitutions(subject_substitutions, body_substitutions)
     return content
 
 
-def _make_substitutions(text: str, substitutions: dict[str, str]) -> str:
+def make_substitutions(text: str, substitutions: dict[str, str]) -> str:
     for key, value in substitutions.items():
         text = re.sub(r'\{\{\s*' + key + r'\s*\}\}', value, text)
     return text

--- a/server/services/email/templates/assignment_inform_email.html
+++ b/server/services/email/templates/assignment_inform_email.html
@@ -16,7 +16,8 @@
     </ul>
 
     <p>You can view this seat's position on the seating chart at:</p>
-    <a href="{{URL}}">View Seating Chart</a>
+
+    <p><a href="{{URL}}">View Seating Chart</a></p>
 
     <p>
       If you have any questions or require further assistance, please do not
@@ -24,10 +25,5 @@
     </p>
 
     <p>Good luck on your exam!</p>
-
-    <p>{{ADDITIONAL_INFO}}</p>
-
-    <p>Best,</p>
-    <p>{{SIGNATURE}}</p>
   </body>
 </html>

--- a/server/templates/email.html.j2
+++ b/server/templates/email.html.j2
@@ -4,39 +4,63 @@
 {% block body %}
 {% call macros.form(form) %}
 <main class="mdl-grid">
-  <div class="mdl-cell mdl-cell--10-col delist">
-    <h5>From</h5>
-    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+
+  <div class="mdl-cell mdl-cell--12-col delist">
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--6-col">
       {{ form.from_addr(class="mdl-textfield__input", type="Email", id="from_addr") }}
-      <label class="mdl-textfield__label" for="from_addr">Sender Email</label>
+      <label class="mdl-textfield__label" for="from_addr">FROM:</label>
     </div>
-    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-      {{ form.signature(class="mdl-textfield__input", type="Name", id="signature") }}
-      <label class="mdl-textfield__label" for="signature">Sender signature</label>
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--6-col">
+      {{ form.to_addr(class="mdl-textfield__input", type="text", id="to_addr") }}
+      <label class="mdl-textfield__label" for="to_addr">TO:</label>
     </div>
   </div>
-  <div class="mdl-cell mdl-cell--10-col delist">
-    <h5>Additional Info</h5>
-    <div class="mdl-textfield mdl-js-textfield">
-      {{ form.additional_info(class="mdl-textfield__input", type="text", rows="10", id="additional_info") }}
-      <label class="mdl-textfield__label" for="additional_info">Additional Info...</label>
+
+  <div class="mdl-cell mdl-cell--12-col delist">
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--6-col">
+      {{ form.cc_addr(class="mdl-textfield__input", type="text", id="cc_addr") }}
+      <label class="mdl-textfield__label" for="cc_addr">CC:</label>
+    </div>
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--6-col">
+      {{ form.bcc_addr(class="mdl-textfield__input", type="text", id="bcc_addr") }}
+      <label class="mdl-textfield__label" for="bcc_addr">BCC:</label>
+    </div>
+  </div>
+
+  <div class="mdl-cell mdl-cell--12-col delist">
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--12-col">
+      {{ form.body(class="mdl-textfield__input", type="text", rows="30", id="body") }}
+      <label class="mdl-textfield__label" for="body">Body:</label>
+    </div>
+    
+  </div>
+
+  <div class="mdl-cell mdl-cell--12-col delist">
+      <div id="preview" style="border: 2px dotted #000; padding: 10px; margin-top: 30px; background-color: #fff;">NO PREVIEW</div>
+  </div>
+
+  <div class="mdl-cell mdl-cell--12-col delist">
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--10-col">
+      {{ form.subject(class="mdl-textfield__input", type="text", rows="10", id="subject") }}
+      <label class="mdl-textfield__label" for="subject">Subject:</label>
+    </div>
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell--2-col">
+      {{ form.body_html(class="mdl-textfield__input", type="checkbox", id="body_html") }}
+      <label class="mdl-textfield__label" for="body_html">HTML Body?</label>
     </div>
   <div>
-  <div class="mdl-cell mdl-cell--10-col delist">
-    <h5>Overrides</h5>
-    <div class="mdl-textfield mdl-js-textfield">
-      {{ form.override_subject(class="mdl-textfield__input", type="Subject", id="subject") }}
-      <label class="mdl-textfield__label" for="subject">Override Email Subject</label>
-    </div>
-    <div class="mdl-textfield mdl-js-textfield">
-      {{ form.override_to_addr(class="mdl-textfield__input", type="Test Email", id="testemail") }}
-      <label class="mdl-textfield__label" for="testemail">Override Receipt Address</label>
-    </div>
-  </div>
+
   <div class="form-buttons">
+    <button class="mdl-button mdl-js-button mdl-button--raised" type="button" onclick="updatePreview()">Preview</button>
     {{ form.submit(class="mdl-button mdl-js-button mdl-button--raised") }}
   </div>
-  <div class="mdl-layout-spacer"></div>
+
+  <script>
+      function updatePreview() {
+          var htmlContent = document.getElementById('body').value;
+          document.getElementById('preview').innerHTML = htmlContent;
+      }
+  </script>
 </main>
 {% endcall %}
 {% endblock %}

--- a/server/templates/students.html.j2
+++ b/server/templates/students.html.j2
@@ -38,6 +38,7 @@
           <th class="sort mdl-data-table__cell--non-numeric" data-sort="sid" style="text-align: center;">Student ID</th>
           <th class="sort mdl-data-table__cell--non-numeric" data-sort="canvas_id" style="text-align: center;">Canvas ID</th>
           <th class="sort mdl-data-table__cell--non-numeric" data-sort="assignment" style="text-align: center;">Seat</th>
+          <th class="sort mdl-data-table__cell--non-numeric" data-sort="emailed" style="text-align: center;">Emailed?</th>
           <th class="sort mdl-data-table__cell--non-numeric" data-sort="assignment" style="text-align: center;">Edit</th>
           <th class="mdl-data-table__cell--non-numeric" style="text-align: center;">Delete</th>
         </tr>
@@ -59,9 +60,6 @@
             <a class="assignment" href="{{ url_for('room', exam=exam, name=seat.room.name, seat=seat.name) }}">
               {{ seat.room.display_name }} {{ seat.name }}
             </a>
-            {% if not student.assignment.emailed %}
-              <div>NOT EMAILED</div><div class="material-icons" style="text-align: center; margin: 0; cursor: pointer;" onclick="location.href = '{{ url_for('email_single_student', exam=exam, student_id=student.id) }}';" style="float: right;">email</div>
-            {% endif %}
           {% else %}
             <span class="assignment" style="text-align: center;">
               <div>NOT ASSIGNED</div>
@@ -80,6 +78,18 @@
                 {% endif %}
               </small>
             </span>
+          {% endif %}
+          </td>
+          <td class="mdl-data-table__cell--non-numeric" style="text-align: center;">
+          {% if student.assignment %}
+            {% if student.assignment.emailed %}
+              <div>EMAILED</div>
+            {% else %}
+              <div>NOT EMAILED</div>
+            {% endif %}
+            <div class="material-icons" style="text-align: center; margin: 0; cursor: pointer;" onclick="location.href = '{{ url_for('email_single_student', exam=exam, student_id=student.id) }}';" style="float: right;">email</div>
+          {% else %}
+            <div>NOT ASSIGNED</div>
           {% endif %}
           </td>
           <td class="mdl-data-table__cell--non-numeric" style="text-align: center;">

--- a/server/views.py
+++ b/server/views.py
@@ -1,5 +1,4 @@
 import re
-
 from flask import abort, redirect, render_template, request, send_file, url_for, flash
 from flask_login import current_user, login_required
 
@@ -7,12 +6,14 @@ from server import app
 from server.models import SeatAssignment, db, Exam, Room, Seat, Student
 from server.forms import ExamForm, RoomForm, ChooseRoomForm, ImportStudentFromSheetForm, \
     ImportStudentFromCanvasRosterForm, DeleteStudentForm, AssignForm, EmailForm, EditStudentForm
+from server.services.email.templates import get_email
 from server.services.google import get_spreadsheet_tabs
 import server.services.canvas as canvas_client
-from server.services.email import email_students, email_student
+from server.services.email import email_about_assignment
 from server.services.core.data import parse_form_and_validate_room, validate_students, \
     parse_student_sheet, parse_canvas_student_roster
 from server.services.core.assign import assign_students
+from server.typings.enum import EmailTemplate
 
 # region Offering CRUDI
 
@@ -377,16 +378,19 @@ def assign(exam):
 def email_all_students(exam):
     form = EmailForm()
     if form.validate_on_submit():
-        success_students, failure_students = email_students(exam, form)
-        if failure_students:
-            names = [s.name for s in failure_students]
-            flash(f"Failed to email students: {', '.join(names)}", 'error')
-        if success_students:
-            names = [s.name for s in success_students]
-            flash(f"Successfully emailed students: {', '.join(names)}", 'success')
-        if not success_students and not failure_students:
-            flash("No students were emailed.", 'warning')
+        successful_emails, failed_emails = email_about_assignment(exam, form, form.to_addr.data)
+        if successful_emails:
+            flash(f"Successfully emailed {len(successful_emails)} students.", 'success')
+        if failed_emails:
+            flash(f"Failed to email students: {', '.join(failed_emails)}", 'error')
+        if not successful_emails and not failed_emails:
+            flash("No email sent.", 'warning')
         return redirect(url_for('students', exam=exam))
+    else:
+        email_prefill = get_email(EmailTemplate.ASSIGNMENT_INFORM_EMAIL)
+        form.subject.data = email_prefill.subject
+        form.body.data = email_prefill.body
+        form.to_addr.data = ','.join([s.email for s in exam.students])
     return render_template('email.html.j2', exam=exam, form=form)
 
 
@@ -394,12 +398,19 @@ def email_all_students(exam):
 def email_single_student(exam, student_id):
     form = EmailForm()
     if form.validate_on_submit():
-        success, payload = email_student(exam, student_id, form)
-        if success:
-            flash(f"Successfully emailed student with id: {student_id}", 'success')
-        else:
-            flash(f"Failed to email student with id: {student_id}\n{payload}", 'error')
+        successful_emails, failed_emails = email_about_assignment(exam, form, form.to_addr.data)
+        if successful_emails:
+            flash(f"Successfully emailed {len(successful_emails)} students.", 'success')
+        if failed_emails:
+            flash(f"Failed to email students: {', '.join(failed_emails)}", 'error')
+        if not successful_emails and not failed_emails:
+            flash("No email sent.", 'warning')
         return redirect(url_for('students', exam=exam))
+    else:
+        email_prefill = get_email(EmailTemplate.ASSIGNMENT_INFORM_EMAIL)
+        form.subject.data = email_prefill.subject
+        form.body.data = email_prefill.body
+        form.to_addr.data = Student.query.get(student_id).email
     return render_template('email.html.j2', exam=exam, form=form)
 
 # endregion

--- a/server/views.py
+++ b/server/views.py
@@ -13,7 +13,6 @@ from server.services.email import email_students, email_student
 from server.services.core.data import parse_form_and_validate_room, validate_students, \
     parse_student_sheet, parse_canvas_student_roster
 from server.services.core.assign import assign_students
-from server.typings.exception import DataValidationError
 
 # region Offering CRUDI
 


### PR DESCRIPTION
Allow emailed status display and re-send email.

![image](https://github.com/berkeley-eecs/seating/assets/82516689/c44b511e-8bd3-4a7f-8b08-2772dd7b437c)

Allow CC and BCC.
Email content editor and preview.
To, CC, BCC all support comma-separated email list.

![image](https://github.com/berkeley-eecs/seating/assets/82516689/16b58058-d096-4f3e-bd66-c71ee55471cc)
