### PR TITLE
Feat: Movable Seats

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -136,8 +136,16 @@ class Room(db.Model):
     )
 
     @property
+    def fixed_seats(self):
+        return [seat for seat in self.seats if seat.fixed]
+
+    @property
+    def movable_seats(self):
+        return [seat for seat in self.seats if not seat.fixed]
+
+    @property
     def rows(self):
-        seats = natsorted(self.seats, key=lambda seat: seat.row)
+        seats = natsorted(self.fixed_seats, key=lambda seat: seat.row)
         return [
             natsorted(g, key=lambda seat: seat.x)
             for _, g in itertools.groupby(seats, lambda seat: seat.row)
@@ -151,18 +159,23 @@ class Seat(db.Model):
     __tablename__ = 'seats'
     id = db.Column(db.Integer, primary_key=True)
     room_id = db.Column(db.ForeignKey('rooms.id'), index=True, nullable=False)
-    name = db.Column(db.String(255), nullable=False)
-    row = db.Column(db.String(255), nullable=False)
-    seat = db.Column(db.String(255), nullable=False, index=True)
-    x = db.Column(db.Float, nullable=False)
-    y = db.Column(db.Float, nullable=False)
+    fixed = db.Column(db.Boolean, default=True, nullable=False)
+    name = db.Column(db.String(255))
+    row = db.Column(db.String(255))
+    seat = db.Column(db.String(255), index=True)
+    x = db.Column(db.Float)
+    y = db.Column(db.Float)
     attributes = db.Column(StringSet, nullable=False)
 
     assignment = db.relationship('SeatAssignment', uselist=False, cascade='all, delete-orphan',
                                  backref=backref('seat', uselist=False, single_parent=True))
 
+    @property
+    def display_name(self):
+        return self.name if self.name else "Movable Seat"
+
     def __repr__(self):
-        return '<Seat {}>'.format(self.name)
+        return '<Seat {}>'.format(self.name_display)
 
 
 class Student(db.Model):

--- a/server/models.py
+++ b/server/models.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 
 from server import app
 from server.utils.date import parse_ISO8601
+from server.utils.misc import arr_to_dict
 
 db = SQLAlchemy(app=app)
 
@@ -142,6 +143,10 @@ class Room(db.Model):
     @property
     def movable_seats(self):
         return [seat for seat in self.seats if not seat.fixed]
+
+    @property
+    def movable_seats_by_attribute(self):
+        return arr_to_dict(self.movable_seats, key_getter=lambda seat: frozenset(seat.attributes))
 
     @property
     def rows(self):

--- a/server/services/core/assign.py
+++ b/server/services/core/assign.py
@@ -1,6 +1,7 @@
 import random
 
 from server.models import SeatAssignment
+from server.utils.misc import arr_to_dict
 
 
 def assign_students(exam):
@@ -24,16 +25,6 @@ def assign_students(exam):
             if (all(a in seat.attributes for a in wants) and  # noqa
                 all(a not in seat.attributes for a in avoids))
         ]
-
-    def arr_to_dict(arr, key_getter=lambda x: x):
-        """
-        Convert an array to a dictionary, grouping by the key returned by key_getter.
-        """
-        from collections import defaultdict
-        dic = defaultdict(list)
-        for x in arr:
-            dic[key_getter(x)].append(x)
-        return dic
 
     assignments = []
     while students:

--- a/server/services/core/data.py
+++ b/server/services/core/data.py
@@ -43,7 +43,7 @@ def _prepare_seat(room_form):
     for row in rows:
         seat = Seat()
         seat.row, seat.seat = row.pop('row', None), row.pop('seat', None)
-        seat.fixed = seat.row and seat.seat
+        seat.fixed = bool(seat.row and seat.seat)
 
         # if we leave either row or seat blank, we regard it as a movable seat
         # movable seats does not have a fixed coordinate or name, but it still attributes

--- a/server/services/core/data.py
+++ b/server/services/core/data.py
@@ -70,9 +70,18 @@ def _prepare_seat(room_form):
                 raise DataValidationError(f'Fixed seat coordinates repeated: {coords}')
             seat_coords.add(coords)
             seat.x, seat.y = coords
-
-        seat.attributes = {k for k, v in row.items() if v.lower() == 'true'}
-        valid_seats.append(seat)
+            _ = row.pop('count', 1)  # discard count column if it exists
+            seat.attributes = {k for k, v in row.items() if v.lower() == 'true'}
+            valid_seats.append(seat)
+        else:
+            # allows count column so we can define multiple movable seats in one row
+            count = row.pop('count', 1)
+            attributes = {k for k, v in row.items() if v.lower() == 'true'}
+            for _ in range(int(count)):
+                seat = Seat()
+                seat.fixed = False
+                seat.attributes = attributes
+                valid_seats.append(seat)
     return valid_seats
 
 

--- a/server/services/core/data.py
+++ b/server/services/core/data.py
@@ -5,7 +5,7 @@ from server.models import Room, Seat, Student, slug
 from server.utils.date import to_ISO8601
 
 
-def parse_form_and_validate_room(exam, room_form):
+def _prepare_room(exam, room_form):
     room = Room(
         exam_id=exam.id,
         name=slug(room_form.display_name.data),
@@ -27,45 +27,59 @@ def parse_form_and_validate_room(exam, room_form):
 
     if existing_room:
         raise DataValidationError('A room with that name and start time already exists')
+
+    return room
+
+
+def _prepare_seat(room_form):
     headers, rows = get_spreadsheet_tab_content(room_form.sheet_url.data,
                                                 room_form.sheet_range.data)
-    if 'row' not in headers:
-        raise DataValidationError('Missing "row" column')
-    elif 'seat' not in headers:
-        raise DataValidationError('Missing "seat" column')
+    if 'row' not in headers or 'seat' not in headers:
+        raise DataValidationError('Missing compulsory columns "row" and/or "seat"')
 
     x, y = 0, -1
     last_row = None
+    valid_seats, seat_names, seat_coords = [], set(), set()
     for row in rows:
         seat = Seat()
-        seat.row = row.pop('row')
-        seat.seat = row.pop('seat')
-        seat.name = seat.row + seat.seat
-        if not seat.name:
-            continue
-        if seat.row != last_row:
-            x = 0
-            y += 1
-        else:
-            x += 1
-        last_row = seat.row
-        x_override = row.pop('x', None)
-        y_override = row.pop('y', None)
-        try:
-            if x_override:
-                x = float(x_override)
-            if y_override:
-                y = float(y_override)
-        except TypeError:
-            raise DataValidationError('xy coordinates must be floats')
-        seat.x = x
-        seat.y = y
+        seat.row, seat.seat = row.pop('row', None), row.pop('seat', None)
+        seat.fixed = seat.row and seat.seat
+
+        # if we leave either row or seat blank, we regard it as a movable seat
+        # movable seats does not have a fixed coordinate or name, but it still attributes
+        if seat.fixed:
+            seat.name = seat.row + seat.seat
+            if seat.name in seat_names:
+                raise DataValidationError(f'Fixed seat name repeated: {seat.name}')
+            seat_names.add(seat.name)
+            if seat.row != last_row:
+                x, y = 0, y + 1
+            else:
+                x += 1
+            last_row = seat.row
+            x_override, y_override = row.pop('x', None), row.pop('y', None)
+            try:
+                if x_override:
+                    x = float(x_override)
+                if y_override:
+                    y = float(y_override)
+            except TypeError:
+                raise DataValidationError('Fixed seat coordinate override must be floats.')
+            coords = x, y
+            if coords in seat_coords:
+                raise DataValidationError(f'Fixed seat coordinates repeated: {coords}')
+            seat_coords.add(coords)
+            seat.x, seat.y = coords
+
         seat.attributes = {k for k, v in row.items() if v.lower() == 'true'}
-        room.seats.append(seat)
-    if len(set(seat.name for seat in room.seats)) != len(room.seats):
-        raise DataValidationError('Seats are not unique')
-    elif len(set((seat.x, seat.y) for seat in room.seats)) != len(room.seats):
-        raise DataValidationError('Seat coordinates are not unique')
+        valid_seats.append(seat)
+    return valid_seats
+
+
+def parse_form_and_validate_room(exam, room_form):
+    room = _prepare_room(exam, room_form)
+    seats = _prepare_seat(room_form)
+    room.seats = seats
     return room
 
 

--- a/server/services/email/__init__.py
+++ b/server/services/email/__init__.py
@@ -33,7 +33,7 @@ def email_about_assignment(exam, form, to_addrs):
                                              "COURSE": exam.offering.name,
                                              "EXAM": exam.display_name,
                                              "ROOM": assignment.seat.room.display_name,
-                                             "SEAT": assignment.seat.name,
+                                             "SEAT": assignment.seat.display_name,
                                              "START_TIME": assignment.seat.room.start_at_time_display,
                                              "DURATION": assignment.seat.room.duration_display,
                                              "URL": urljoin(

--- a/server/templates/macros.html.j2
+++ b/server/templates/macros.html.j2
@@ -31,12 +31,59 @@
         </small></span>
     {% endif %}
   </h4>
+
   {% if room.movable_seats %}
-    <h6>Movable Seats</h6>
-    <div>
-    There are {{ room.movable_seats|length }} movable seats in this room.
+    <h5>Movable Seats</h5>
+    {% set circle_size = 24 %}
+    <div style="width: 40%; margin: 0 auto; text-align: left;">
+    <div style="text-align: center;">There are {{ room.movable_seats|length }} movable seats in this room.</div>
+    <ul>
+    {% for attr in room.movable_seats_by_attribute %}
+      <li>{{ ','.join(attr) }}
+
+      {% for seat in room.movable_seats_by_attribute[attr] %}
+        {% if staff %}
+          {% if seat.assignment %}
+            <a id={{ seat.id }} style="font-size: {{ circle_size }}px;"
+              href="{{ url_for('student', exam=exam, canvas_id=seat.assignment.student.canvas_id) }}">
+              &#x25CF;
+            </a>
+          {% else %}
+            <span id={{ seat.id }} style="font-size: {{ circle_size }}px;">
+              &#x25CB;
+            </span>
+          {% endif %}
+        {% endif %}
+        <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.id }}">
+        {{ seat.id }}
+          {% if show_attributes %}
+            {% for attribute in seat.attributes %}
+              <br>{{ attribute|upper }}
+            {% endfor %}
+          {% endif %}
+          {% if staff and seat.assignment %}
+            <br>{{ seat.assignment.student.name }}
+            <br>
+              <img class="photo" src="../../students/{{ seat.assignment.student.email }}/photo"/>
+            <br>{{ seat.assignment.student.sid }}
+          {% endif %}
+        </div>
+      {% endfor %}
+
+      {% for seat in room.movable_seats_by_attribute[attr] %}
+        {% if seat.id == highlight_seat_id %}
+          <span><strong>(YOUR WILL USE A SEAT FROM THIS CATEGORY)</strong></span>
+        {% endif %}
+      {% endfor %}
+
+      </li>
+    {% endfor %}
+    </ul>
     </div>
   {% endif %}
+
+  {% if room.fixed_seats %}
+  <h5>Fixed Seats</h5>
   <h6>Front</h6>
   {% set x_min = room.fixed_seats|map(attribute='x')|min %}
   {% set x_max = room.fixed_seats|map(attribute='x')|max %}
@@ -62,11 +109,11 @@
         {% else %}
           {% set class = 'seat' %}
         {% endif %}
-        <div id="{{ seat.name }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
+        <div id="{{ seat.id }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
       {% if staff and seat.assignment %}
       </a>
       {% endif %}
-      <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.name }}">
+      <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.id }}">
         {{ seat.name }}
         {% if show_attributes %}
         {% for attribute in seat.attributes %}
@@ -88,6 +135,7 @@
   </div>
   </div>
   <h6>Back</h6>
+  {% endif %}
 </div>
 {% endif %}
 {% endmacro %}

--- a/server/templates/macros.html.j2
+++ b/server/templates/macros.html.j2
@@ -16,7 +16,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro room(room, highlight_seat=none, show_attributes=false, staff=true) %}
+{% macro room(room, highlight_seat_id=none, show_attributes=false, staff=true) %}
 {% if room.seats %}
 <div class="room">
   <h4>{{ room.display_name }}
@@ -31,53 +31,59 @@
         </small></span>
     {% endif %}
   </h4>
+  {% if room.movable_seats %}
+    <h6>Movable Seats</h6>
+    <div>
+    There are {{ room.movable_seats|length }} movable seats in this room.
+    </div>
+  {% endif %}
   <h6>Front</h6>
-  {% set x_min = room.seats|map(attribute='x')|min %}
-  {% set x_max = room.seats|map(attribute='x')|max %}
-  {% set y_min = room.seats|map(attribute='y')|min %}
-  {% set y_max = room.seats|map(attribute='y')|max %}
+  {% set x_min = room.fixed_seats|map(attribute='x')|min %}
+  {% set x_max = room.fixed_seats|map(attribute='x')|max %}
+  {% set y_min = room.fixed_seats|map(attribute='y')|min %}
+  {% set y_max = room.fixed_seats|map(attribute='y')|max %}
   {% set scale = 23 %}
   <div class="scroll" style="overflow-y:hidden">
   <div class="seats" style="width:{{ scale * (x_max - x_min + 1) }}px;height:{{ scale * (y_max - y_min + 1) }}px">
   {% for row in room.rows %}
-  {% for seat in row %}
-    {% set x = scale * (x_max - seat.x) %}
-    {% set y = scale * (seat.y - y_min) %}
-    {% if loop.first %}
-      <div class="seat-label" style="left:{{ x + 30 }}px;top:{{ y }}px">{{ seat.name }}</div>
-    {% endif %}
-    {% if staff and seat.assignment %}
-    <a href="{{ url_for('student', exam=exam, canvas_id=seat.assignment.student.canvas_id) }}">
-    {% endif %}
-      {% if seat.name == highlight_seat %}
-        {% set class = 'seat highlight' %}
-      {% elif staff and seat.assignment %}
-        {% set class = 'seat occupied' %}
-      {% else %}
-        {% set class = 'seat' %}
-      {% endif %}
-      <div id="{{ seat.name }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
-    {% if staff and seat.assignment %}
-    </a>
-    {% endif %}
-    <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.name }}">
-      {{ seat.name }}
-      {% if show_attributes %}
-      {% for attribute in seat.attributes %}
-        <br>{{ attribute|upper }}
-      {% endfor %}
+    {% for seat in row %}
+      {% set x = scale * (x_max - seat.x) %}
+      {% set y = scale * (seat.y - y_min) %}
+      {% if loop.first %}
+        <div class="seat-label" style="left:{{ x + 30 }}px;top:{{ y }}px">{{ seat.name }}</div>
       {% endif %}
       {% if staff and seat.assignment %}
-        <br>{{ seat.assignment.student.name }}
-        <br>
-          <img class="photo" src="../../students/{{ seat.assignment.student.email }}/photo"/>
-        <br>{{ seat.assignment.student.sid }}
+      <a href="{{ url_for('student', exam=exam, canvas_id=seat.assignment.student.canvas_id) }}">
       {% endif %}
-    </div>
-    {% if loop.last %}
-      <div class="seat-label" style="left:{{ x - 50 }}px;top:{{ y }}px">{{ seat.name }}</div>
-    {% endif %}
-  {% endfor %}
+        {% if seat.id == highlight_seat_id %}
+          {% set class = 'seat highlight' %}
+        {% elif staff and seat.assignment %}
+          {% set class = 'seat occupied' %}
+        {% else %}
+          {% set class = 'seat' %}
+        {% endif %}
+        <div id="{{ seat.name }}" class="{{ class }}" style="left:{{ x }}px;top:{{ y }}px"></div>
+      {% if staff and seat.assignment %}
+      </a>
+      {% endif %}
+      <div class="seat-tooltip mdl-tooltip mdl-tooltip--large" for="{{ seat.name }}">
+        {{ seat.name }}
+        {% if show_attributes %}
+        {% for attribute in seat.attributes %}
+          <br>{{ attribute|upper }}
+        {% endfor %}
+        {% endif %}
+        {% if staff and seat.assignment %}
+          <br>{{ seat.assignment.student.name }}
+          <br>
+            <img class="photo" src="../../students/{{ seat.assignment.student.email }}/photo"/>
+          <br>{{ seat.assignment.student.sid }}
+        {% endif %}
+      </div>
+      {% if loop.last %}
+        <div class="seat-label" style="left:{{ x - 50 }}px;top:{{ y }}px">{{ seat.name }}</div>
+      {% endif %}
+    {% endfor %}
   {% endfor %}
   </div>
   </div>

--- a/server/templates/room.html.j2
+++ b/server/templates/room.html.j2
@@ -4,5 +4,5 @@
 {% block title %}{{ room.display_name }} | {{ super() }}{% endblock %}
 
 {% block body %}
-{{ macros.room(room, highlight_seat=seat, show_attributes=True) }}
+{{ macros.room(room, highlight_seat_id=seat_id, show_attributes=True) }}
 {% endblock %}

--- a/server/templates/seat.html.j2
+++ b/server/templates/seat.html.j2
@@ -11,20 +11,20 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
-    <title>{% block title %}{{ room.display_name }} {{seat.name}}{% endblock %}</title>
+    <title>{% block title %}{{ room.display_name }} {{seat.display_name}}{% endblock %}</title>
   </head>
   <body>
     <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
       <header class="mdl-layout__header">
         <div class="mdl-layout__header-row">
           <span class="hidden-small mdl-layout__title">
-            {{ room.exam.display_name }} - {{ room.display_name }} {{seat.name}} 
+            {{ room.exam.display_name }} - {{ room.display_name }} {{seat.display_name}} 
           </span>
         </div>
       </header>
       <main class="mdl-layout__content">
         {% block body %}
-        {{ macros.room(room, highlight_seat=seat.name, staff=false) }}
+        {{ macros.room(room, highlight_seat_id=seat.id, staff=false) }}
         {% endblock %}
       </main>
     </div>

--- a/server/templates/student.html.j2
+++ b/server/templates/student.html.j2
@@ -14,8 +14,8 @@
     <p>
     {% if student.assignment %}
       {% set seat = student.assignment.seat %}
-      <a href="{{ url_for('room', exam=exam, id=seat.room.id, seat=seat.name) }}">
-        {{ seat.room.display_name }} {{ seat.name }}
+      <a href="{{ url_for('room', exam=exam, id=seat.room.id, seat=seat.id) }}">
+        {{ seat.room.display_name }} {{ seat.display_name }}
       </a><br><br>
       <a target="_blank" href="{{ url_for('single_seat', seat_id=seat.id) }}">
         Sharable Link to This Seat

--- a/server/templates/student.html.j2
+++ b/server/templates/student.html.j2
@@ -17,7 +17,7 @@
       <a href="{{ url_for('room', exam=exam, id=seat.room.id, seat=seat.id) }}">
         {{ seat.room.display_name }} {{ seat.display_name }}
       </a><br><br>
-      <a target="_blank" href="{{ url_for('single_seat', seat_id=seat.id) }}">
+      <a target="_blank" href="{{ url_for('student_single_seat', seat_id=seat.id) }}">
         Sharable Link to This Seat
       </a>
     {% else %}

--- a/server/templates/students.html.j2
+++ b/server/templates/students.html.j2
@@ -57,8 +57,8 @@
           <td class="mdl-data-table__cell--non-numeric" style="text-align: center;">
           {% if student.assignment %}
             {% set seat = student.assignment.seat %}
-            <a class="assignment" href="{{ url_for('room', exam=exam, id=seat.room.id, seat=seat.name) }}">
-              {{ seat.room.display_name }} {{ seat.name }}
+            <a class="assignment" href="{{ url_for('room', exam=exam, id=seat.room.id, seat=seat.id) }}">
+              {{ seat.room.display_name }} {{ seat.display_name }}
             </a>
           {% else %}
             <span class="assignment" style="text-align: center;">

--- a/server/utils/misc.py
+++ b/server/utils/misc.py
@@ -1,0 +1,9 @@
+def arr_to_dict(arr, key_getter=lambda x: x):
+    """
+    Convert an array to a dictionary, grouping by the key returned by key_getter.
+    """
+    from collections import defaultdict
+    dic = defaultdict(list)
+    for x in arr:
+        dic[key_getter(x)].append(x)
+    return dic

--- a/server/views.py
+++ b/server/views.py
@@ -250,8 +250,8 @@ def room(exam, id):
     Displays the room diagram, with an optional seat highlighted.
     """
     room = Room.query.filter_by(exam_id=exam.id, id=id).first_or_404()
-    seat = request.args.get('seat')
-    return render_template('room.html.j2', exam=exam, room=room, seat=seat)
+    seat_id = request.args.get('seat')
+    return render_template('room.html.j2', exam=exam, room=room, seat_id=seat_id)
 # endregion
 
 # region Student CRUDI

--- a/tests/fixtures/seat.json
+++ b/tests/fixtures/seat.json
@@ -41,6 +41,18 @@
         "x": 1,
         "y": 1,
         "attributes": ["Righty"]
+      },
+      {
+        "id": 5,
+        "room_id": 1,
+        "fixed": false,
+        "attributes": ["Lefty"]
+      },
+      {
+        "id": 6,
+        "room_id": 1,
+        "fixed": false,
+        "attributes": ["Righty"]
       }
     ]
   }

--- a/tests/fixtures/seat.json
+++ b/tests/fixtures/seat.json
@@ -53,6 +53,12 @@
         "room_id": 1,
         "fixed": false,
         "attributes": ["Righty"]
+      },
+      {
+        "id": 7,
+        "room_id": 1,
+        "fixed": false,
+        "attributes": ["Lefty"]
       }
     ]
   }


### PR DESCRIPTION
## Overview
This PR introduces the concept of movable seats. They are like normal seats associated with a room, but they only have attributes fields (lefty, righty etc) and do not have position coordinate (x, y), name ("A1", "C5"...), row number, column number etc. Movable seats in the same room with the same set of attributes are basically indistinguishable from each other. 

## Motivation
Here are some canonical use case for movable seats:
- We are using a new exam room and we only know the total number of seats is 200, and do not have capacity to chart the seat positions. So, we add 200 movable seats without attributes to this room, and let students pick their seat when they arrive.
- We are using a small room with 20 seats. The room is so small that assigning seating location is pointless. We will add 20 movable seat without attributes, and let TA to arrange the 20 students on the spot.
- We are using a very small room for DSP with 3 LEFTY tables and 3 RIGHTY tables. We will add 3 movable seats with LEFTY attributes and 3 with RIGHTY attributes, and assign 6 students in. They will come in and TA on the spot will give them a table they want. Exactly who gets which is not important.

## Future Work...
This feature will be more useful if we could allow student to indicate preferences to want/avoid certain rooms (DSP room, for example) - we will build this in the future.

## How to add movable seats?
Now (this will be moved to README), how to add movable seats?
It is the same as adding a regular seat row in your room google spreadsheet, but leave the "row" and "seat" column blank. (That makes sense - movable seats do not have a row number or seat number). If either of the column is missing, then the parsing algorithm will take it to be a movable seat.
Since all movable seats with the same attributes are essentially indistinguishable, we also additionally support "count" column now to make it easier to bulk add movable seats with the same attributes. Simply add a count column in addition to the old room spreadsheet template, and put in the number.

Example: add 1 movable seats with RIGHTY attribute and 2 movable seats with LEFTY attribute.

You can either:

![image](https://github.com/berkeley-eecs/seating/assets/82516689/d82d73cd-d41d-488c-8245-25b745dc6786)

OR, using `Count` column

![image](https://github.com/berkeley-eecs/seating/assets/82516689/015be87d-4864-4200-80a9-5689d87bb329)

