### PR TITLE
Fix: DB-Layer Cascading Delete

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -66,7 +66,7 @@ class Exam(db.Model):
     __tablename__ = 'exams'
     id = db.Column(db.Integer, primary_key=True)
     offering_canvas_id = db.Column(db.ForeignKey(
-        'offerings.canvas_id'), index=True, nullable=False)
+        'offerings.canvas_id', ondelete='CASCADE'), index=True, nullable=False)
     name = db.Column(db.String(255), nullable=False, index=True)
     display_name = db.Column(db.String(255), nullable=False)
     is_active = db.Column(db.BOOLEAN, nullable=False)
@@ -110,7 +110,7 @@ class Exam(db.Model):
 class Room(db.Model):
     __tablename__ = 'rooms'
     id = db.Column(db.Integer, primary_key=True)
-    exam_id = db.Column(db.ForeignKey('exams.id'), index=True, nullable=False)
+    exam_id = db.Column(db.ForeignKey('exams.id', ondelete='CASCADE'), index=True, nullable=False)
     name = db.Column(db.String(255), nullable=False, index=True)
     display_name = db.Column(db.String(255), nullable=False)
     start_at = db.Column(db.String(255))
@@ -163,7 +163,7 @@ class Room(db.Model):
 class Seat(db.Model):
     __tablename__ = 'seats'
     id = db.Column(db.Integer, primary_key=True)
-    room_id = db.Column(db.ForeignKey('rooms.id'), index=True, nullable=False)
+    room_id = db.Column(db.ForeignKey('rooms.id', ondelete='CASCADE'), index=True, nullable=False)
     fixed = db.Column(db.Boolean, default=True, nullable=False)
     name = db.Column(db.String(255))
     row = db.Column(db.String(255))
@@ -186,7 +186,7 @@ class Seat(db.Model):
 class Student(db.Model):
     __tablename__ = 'students'
     id = db.Column(db.Integer, primary_key=True)
-    exam_id = db.Column(db.ForeignKey('exams.id'), index=True, nullable=False)
+    exam_id = db.Column(db.ForeignKey('exams.id', ondelete='CASCADE'), index=True, nullable=False)
     canvas_id = db.Column(db.String(255), nullable=False, index=True)
     email = db.Column(db.String(255), index=True, nullable=False)
     name = db.Column(db.String(255), nullable=False)
@@ -210,8 +210,8 @@ class SeatAssignment(db.Model):
     __table_args__ = (
         PrimaryKeyConstraint('student_id', 'seat_id'),
     )
-    student_id = db.Column(db.ForeignKey('students.id'), index=True, nullable=False)
-    seat_id = db.Column(db.ForeignKey('seats.id'), index=True, nullable=False)
+    student_id = db.Column(db.ForeignKey('students.id', ondelete='CASCADE'), index=True, nullable=False)
+    seat_id = db.Column(db.ForeignKey('seats.id', ondelete='CASCADE'), index=True, nullable=False)
     emailed = db.Column(db.Boolean, default=False, index=True, nullable=False)
 
 

--- a/server/views.py
+++ b/server/views.py
@@ -338,7 +338,7 @@ def delete_students(exam):
         did_not_exist = set()
         if not form.use_all_emails.data:
             did_not_exist = set(emails) - deleted
-        students.delete()
+        students.delete(synchronize_session=False)
         db.session.commit()
         if not deleted and not did_not_exist:
             abort(404, "No change has been made.")


### PR DESCRIPTION
My last version of schema file only set up cascading delete at orm level. This is respected when you do `db.session.delete(xxx)` but is not respected when you do bulk deletion like this `Student.query.filter(....).delete()`. The latter simply emits a DELETE sql clause and orm is not involved.

This PR sets up cascading delete on database layer too.

reference: https://github.com/sqlalchemy/sqlalchemy/discussions/7974