### PR TITLE
Feat: Scoped Credential for Canvas OAuth2

### DIFF
--- a/server/services/auth/__init__.py
+++ b/server/services/auth/__init__.py
@@ -3,6 +3,7 @@ from flask import redirect, request, session, url_for
 import server.services.canvas as canvas_client
 from flask_login import LoginManager
 from flask_oauthlib.client import OAuth
+from .scope import scopes
 
 from server import app
 
@@ -27,6 +28,7 @@ if not canvas_client.is_mock_canvas():
         access_token_method='POST',
         access_token_url=canvas_server_url + 'login/oauth2/token',
         authorize_url=canvas_server_url + 'login/oauth2/auth',
+        request_token_params={'scope': ' '.join(scopes)},
     )
 else:
     # dev login uses HTTP so we need to allow that for OAuth2

--- a/server/services/auth/scope.py
+++ b/server/services/auth/scope.py
@@ -2,5 +2,5 @@ scopes = [
     'url:GET|/api/v1/courses/:id',
     'url:GET|/api/v1/users/:id',
     'url:GET|/api/v1/users/:user_id/courses',
-    'url:GET|/api/v1/courses/:course_id/search_users'
+    # 'url:GET|/api/v1/courses/:course_id/search_users'
 ]

--- a/server/services/auth/scope.py
+++ b/server/services/auth/scope.py
@@ -1,0 +1,6 @@
+scopes = [
+    'url:GET|/api/v1/courses/:id',
+    'url:GET|/api/v1/users/:id',
+    'url:GET|/api/v1/users/:user_id/courses',
+    'url:GET|/api/v1/courses/:course_id/search_users'
+]


### PR DESCRIPTION
Previously we are using an unscoped key.

Now, we are using a scoped key.

FOR NOW: The last endpoint is temporarily commented out because it seems that endpoint is not granted yet. Shall fix it once the endpoint is granted.