### PR TITLE
Feat: Filtered Course List & Add Course Page

### DIFF
--- a/server/controllers/__init__.py
+++ b/server/controllers/__init__.py
@@ -47,7 +47,7 @@ class ExamConverter(BaseConverter):
                       "You have not been assigned a seat for this exam. " + GENERAL_STUDENT_HINT)
             raise Redirect(url_for('student_single_seat', seat_id=exam_student_seat.seat.id))
         else:
-            abort(403, "You are not authorized to view this page." + GENERAL_STUDENT_HINT)
+            abort(403, "You are not authorized to view this page. " + GENERAL_STUDENT_HINT)
 
         return exam
 
@@ -71,18 +71,7 @@ class OfferingConverter(BaseConverter):
         offering = Offering.query.filter_by(
             canvas_id=canvas_id).one_or_none()
         if not offering:
-            import server.services.canvas as canvas_client
-            # visiting a offering route the first time as a staff member will create it in db
-            if str(canvas_id) not in current_user.staff_offerings:
-                abort(404,
-                      "This course offering is not initialized for seating." +
-                      GENERAL_STUDENT_HINT)
-            course_raw = canvas_client.get_course(canvas_id)
-            if not canvas_client.is_course_valid(course_raw):
-                abort(404, "Offering not found from Canvas.")
-            offering = canvas_client.api_course_to_model(course_raw)
-            db.session.add(offering)
-            db.session.commit()
+            abort(404, "This course offering is not initialized for seating. " + GENERAL_STUDENT_HINT)
         return offering
 
     def to_url(self, offering):

--- a/server/forms.py
+++ b/server/forms.py
@@ -20,7 +20,7 @@ class ChooseCourseOfferingForm(FlaskForm):
     def __init__(self, offering_list=None, *args, **kwargs):
         super(ChooseCourseOfferingForm, self).__init__(*args, **kwargs)
         if offering_list is not None:
-            self.offerings.choices = [(o.canvas_id, str(o)) for o in offering_list]
+            self.offerings.choices = [(o.canvas_id, str(o)) for o in offering_list]  # (value, label)
 
 
 class ExamForm(FlaskForm):

--- a/server/forms.py
+++ b/server/forms.py
@@ -8,6 +8,21 @@ from wtforms.validators import Email, InputRequired, URL, Optional
 from server.controllers import exam_regex
 
 
+class MultiCheckboxField(SelectMultipleField):
+    widget = widgets.ListWidget(prefix_label=False)
+    option_widget = widgets.CheckboxInput()
+
+
+class ChooseCourseOfferingForm(FlaskForm):
+    submit = SubmitField('import')
+    offerings = MultiCheckboxField('select_offerings')
+
+    def __init__(self, offering_list=None, *args, **kwargs):
+        super(ChooseCourseOfferingForm, self).__init__(*args, **kwargs)
+        if offering_list is not None:
+            self.offerings.choices = [(o.canvas_id, str(o)) for o in offering_list]
+
+
 class ExamForm(FlaskForm):
     display_name = StringField('display_name', [InputRequired()], render_kw={
                                "placeholder": "Midterm 1"})
@@ -18,11 +33,6 @@ class ExamForm(FlaskForm):
         pattern = '^{}$'.format(exam_regex)
         if not re.match(pattern, field.data):
             raise ValidationError('Exam name must be match pattern {}'.format(pattern))
-
-
-class MultiCheckboxField(SelectMultipleField):
-    widget = widgets.ListWidget(prefix_label=False)
-    option_widget = widgets.CheckboxInput()
 
 
 class RoomForm(FlaskForm):
@@ -44,7 +54,7 @@ class ChooseRoomForm(FlaskForm):
     def __init__(self, room_list=None, *args, **kwargs):
         super(ChooseRoomForm, self).__init__(*args, **kwargs)
         if room_list is not None:
-            self.rooms.choices = [(item, item) for item in room_list]
+            self.rooms.choices = [(item, item) for item in room_list]  # (value, label)
 
 
 class UploadRoomForm(FlaskForm):

--- a/server/models.py
+++ b/server/models.py
@@ -55,6 +55,9 @@ class Offering(db.Model):
     def start_at_date(self):
         return parse_ISO8601(self.start_at)
 
+    def __str__(self):
+        return f"{self.start_at_date.strftime('%Y-%m')} | {self.code} | {self.name}"
+
     def __repr__(self):
         return '<Offering {}>'.format(self.name)
 

--- a/server/services/canvas/__init__.py
+++ b/server/services/canvas/__init__.py
@@ -101,7 +101,7 @@ def get_student_roster_for_offering(offering_canvas_id, key=None):
 
 def api_course_to_model(course: Course | FakeCourse) -> Offering:
     return Offering(
-        canvas_id=course.id,
+        canvas_id=str(course.id),
         name=course.name,
         code=course.course_code,
         start_at=course.start_at,

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -13,6 +13,13 @@ header a {
   font-weight: inherit;
 }
 
+.main-container {
+  /* margin: 0 auto;
+  padding: 20px 0; */
+  max-width: 960px;
+  /* justify-content: center; */
+}
+
 .add-item {
   /* Dropdown menu: creating new items */
   border-bottom: 1px solid #e8e8e8;

--- a/server/static/js/utils.js
+++ b/server/static/js/utils.js
@@ -1,0 +1,5 @@
+function confirmAction(hint, targetUrl) {
+  if (confirm(hint)) {
+    location.href = targetUrl;
+  }
+}

--- a/server/templates/base.html.j2
+++ b/server/templates/base.html.j2
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/flash.css') }}">
+    <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
     {% block head %}{% endblock %}
     <title>{% block title %}{{ title }}{% endblock %}</title>
   </head>

--- a/server/templates/exam.html.j2
+++ b/server/templates/exam.html.j2
@@ -6,6 +6,11 @@
   <div class="mdl-cell mdl-cell--12-col">
     <h4>Rooms</h4>
     <ul class="mdl-list">
+    {% if exam.rooms|length == 0 %}
+      <li class="mdl-list__item">
+        <span>No room set up yet.</span>
+      </li>
+    {% endif %}
     {% for room in exam.rooms %}
       <li class="mdl-list__item">
         <a class="mdl-list__item-primary-content" href="{{ url_for('room', exam=exam, id=room.id) }}">

--- a/server/templates/exam.html.j2
+++ b/server/templates/exam.html.j2
@@ -27,7 +27,9 @@
           </small></span>
         {% endif %}
         <div class="material-icons std" onclick="location.href = '{{ url_for('edit_room', exam=exam, id=room.id) }}';" style="float: right;">edit</div>
-        <div class="material-icons std" onclick="location.href = '{{ url_for('delete_room', exam=exam, id=room.id) }}';" style="float: right;">clear</div>
+        <div class="material-icons std" style="float: right;"
+          onclick="confirmAction('Are you sure you want to delete this room?', '{{ url_for('delete_room', exam=exam, id=room.id) }}');"
+        >clear</div>
       </li>
     {% endfor %}
     </ul>

--- a/server/templates/new_offerings.html.j2
+++ b/server/templates/new_offerings.html.j2
@@ -6,6 +6,7 @@
 <div class="mdl-grid main-container">
   <div class="mdl-cell mdl-cell--12-col">
     <h5>Choose courses to set up exams with:</h5>
+    <p>If you expect to see an offering but it is not listed, please make sure its corresponding Canvas course exists and is active.</p>
   </div>
   {% call macros.form(form) %}
     <div class="checkbox">{{ form.offerings }}</div>

--- a/server/templates/new_offerings.html.j2
+++ b/server/templates/new_offerings.html.j2
@@ -3,7 +3,7 @@
 
 {% block body %}
 
-<div class="mdl-grid">
+<div class="mdl-grid main-container">
   <div class="mdl-cell mdl-cell--12-col">
     <h5>Choose courses to set up exams with:</h5>
   </div>

--- a/server/templates/new_offerings.html.j2
+++ b/server/templates/new_offerings.html.j2
@@ -1,0 +1,17 @@
+{% extends 'base.html.j2' %}
+{% import 'macros.html.j2' as macros with context %}
+
+{% block body %}
+
+<div class="mdl-grid">
+  <div class="mdl-cell mdl-cell--12-col">
+    <h5>Choose courses to set up exams with:</h5>
+  </div>
+  {% call macros.form(form) %}
+    <div class="checkbox">{{ form.offerings }}</div>
+    <div class="form-buttons">{{ form.submit(class="mdl-button mdl-js-button mdl-button--raised") }}</div>
+  {% endcall %}
+</div>
+
+{% endblock %}
+

--- a/server/templates/select_exam.html.j2
+++ b/server/templates/select_exam.html.j2
@@ -6,6 +6,11 @@
   <div class="mdl-cell mdl-cell--12-col">
     <h4>Exams</h4>
     <ul class="mdl-list">
+    {% if exams|length == 0 %}
+      <li class="mdl-list__item">
+        <span>No exams created yet.</span>
+      </li>
+    {% endif %}
     {% for exam in exams %}
       <li class="mdl-list__item">
         {% if is_staff %}
@@ -19,6 +24,11 @@
         {% endif %}
       </li>
     {% endfor %}
+    {% if not is_staff %}
+      <li class="mdl-list__item">
+        <span>If you expect to see an exam but it is not here, contact your course staff.</span>
+      </li>
+    {% endif %}
     </ul>
   {% if is_staff %}
   </div>

--- a/server/templates/select_exam.html.j2
+++ b/server/templates/select_exam.html.j2
@@ -20,7 +20,9 @@
           {{ exam.display_name }}
         </a>
         {% if is_staff %}
-        <div class="material-icons std" onclick="location.href = '{{ url_for('delete_exam', exam=exam) }}';" style="float: right">clear</div>
+        <div class="material-icons std" 
+          onclick="confirmAction('Are you sure you want to delete this exam?', '{{ url_for('delete_exam', exam=exam) }}');"
+          style="float: right">clear</div>
         {% endif %}
       </li>
     {% endfor %}

--- a/server/templates/select_offering.html.j2
+++ b/server/templates/select_offering.html.j2
@@ -6,7 +6,7 @@
   <div class="mdl-cell mdl-cell--12-col">
     <h4>Staff Course Offerings</h4>
     <div>
-      <p>The following course offerings that you are a staff member of already have exams set up. You can now manage their exams. You can add manage exams for more courses you are a staff member of by clicking the button below.
+      <p>The following course offerings that you are a staff member of already have exams set up. You can now manage their exams. You can add more courses you are a staff member of by clicking the button below.
       </p>
     </div>
     <ul class="mdl-list">
@@ -47,10 +47,14 @@
     {% endif %}
     {% for offering in student_offerings_existing %}
       <li class="mdl-list__item">
+        <div style="width: 15%;">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
-         <a class="mdl-list__item-primary-content" href="{{ url_for('offering', offering=offering) }}">
+        </div>
+        <div style="width: 85%;">
+        <a class="mdl-list__item-primary-content" href="{{ url_for('offering', offering=offering) }}">
            {{ offering.name }}
         </a>
+        </div>
       </li>
     {% endfor %}
     </ul>
@@ -67,8 +71,12 @@
     {% endif %}
     {% for offering in other_offerings_existing %}
       <li class="mdl-list__item"> 
+        <div style="width: 15%;">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
+        </div>
+        <div style="width: 85%;">
         {{ offering.name }}
+        </div>
       </li>
     {% endfor %}
     </ul>

--- a/server/templates/select_offering.html.j2
+++ b/server/templates/select_offering.html.j2
@@ -26,7 +26,9 @@
         </a>
         </div>
         <div style="width: 5%;">
-        <div class="material-icons std" onclick="location.href = '{{ url_for('delete_offering', offering=offering) }}';" style="float: right;">delete</div>
+        <div class="material-icons std" style="float: right;"
+            onclick="confirmAction('Are you sure you want to delete this offering?', '{{ url_for('delete_offering', offering=offering) }}');"
+            >clear</div>
         </div>
       </li>
     {% endfor %}

--- a/server/templates/select_offering.html.j2
+++ b/server/templates/select_offering.html.j2
@@ -2,7 +2,7 @@
 {% import 'macros.html.j2' as macros with context %}
 
 {% block body %}
-<main class="rooms mdl-grid">
+<section class="rooms mdl-grid">
   <div class="mdl-cell mdl-cell--12-col">
     <h4>Staff Course Offerings</h4>
     <div>

--- a/server/templates/select_offering.html.j2
+++ b/server/templates/select_offering.html.j2
@@ -2,11 +2,11 @@
 {% import 'macros.html.j2' as macros with context %}
 
 {% block body %}
-<section class="rooms mdl-grid">
+<main class="rooms mdl-grid">
   <div class="mdl-cell mdl-cell--12-col">
-    <h4>Staff Offerings</h4>
+    <h4>Staff Course Offerings</h4>
     <div>
-      <p>The following course offerings that you are a staff member of already have exams set up. You can now manage their exams. You can add manage exams for more courses you are a staff member of by clicking on the "Add course offering" button.
+      <p>The following course offerings that you are a staff member of already have exams set up. You can now manage their exams. You can add manage exams for more courses you are a staff member of by clicking the button below.
       </p>
     </div>
     <ul class="mdl-list">
@@ -14,20 +14,27 @@
       <li class="mdl-list__item">
         You are not a staff member in any course offerings with exams set up.
       </li>
-      
     {% endif %}
     {% for offering in staff_offerings_existing %}  
-      <li class="mdl-list__item">
+      <li class="mdl-list__item"  style="display: flex; justify-content: space-between;">
+        <div style="width: 15%;">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
+        </div>
+        <div style="width: 80%;">
         <a class="mdl-list__item-primary-content" href="{{ url_for('offering', offering=offering) }}">
           {{ offering.name }}
         </a>
+        </div>
+        <div style="width: 5%;">
+        <div class="material-icons std" onclick="location.href = '{{ url_for('delete_offering', offering=offering) }}';" style="float: right;">delete</div>
+        </div>
       </li>
     {% endfor %}
     </ul>
-    <a class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" href="{{ url_for('add_offerings') }}">Add course offering</a>
-
-    <h4>Student Offerings</h4>
+    <div style="display: flex; justify-content: center;">
+      <a class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" href="{{ url_for('add_offerings') }}">Import courses from canvas</a>
+    </div>
+    <h4>Student Course Offerings</h4>
     <div>
       <p>The following course offerings that you are a student of already have exams set up. You can now view your own seat assignments and exam schedule. If you expect to see a course here but it is not here, your course staff have not yet set up exams for the course yet in this system. Contact your course staff.
       </p>
@@ -47,7 +54,7 @@
       </li>
     {% endfor %}
     </ul>
-    <h4>Other Offerings</h4>
+    <h4>Other Course Offerings</h4>
     <div>
     <p>In the following course offerings you are neither a staff member nor a student, but exams have been set up. You cannot do anything with these offerings.
     </p>
@@ -59,7 +66,7 @@
       </li>
     {% endif %}
     {% for offering in other_offerings_existing %}
-      <li class="mdl-list__item">
+      <li class="mdl-list__item"> 
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
         {{ offering.name }}
       </li>

--- a/server/templates/select_offering.html.j2
+++ b/server/templates/select_offering.html.j2
@@ -5,8 +5,18 @@
 <section class="rooms mdl-grid">
   <div class="mdl-cell mdl-cell--12-col">
     <h4>Staff Offerings</h4>
+    <div>
+      <p>The following course offerings that you are a staff member of already have exams set up. You can now manage their exams. You can add manage exams for more courses you are a staff member of by clicking on the "Add course offering" button.
+      </p>
+    </div>
     <ul class="mdl-list">
-    {% for offering in staff_offerings %}
+    {% if staff_offerings_existing == [] %}
+      <li class="mdl-list__item">
+        You are not a staff member in any course offerings with exams set up.
+      </li>
+      
+    {% endif %}
+    {% for offering in staff_offerings_existing %}  
       <li class="mdl-list__item">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
         <a class="mdl-list__item-primary-content" href="{{ url_for('offering', offering=offering) }}">
@@ -15,9 +25,20 @@
       </li>
     {% endfor %}
     </ul>
+    <a class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" href="{{ url_for('add_offerings') }}">Add course offering</a>
+
     <h4>Student Offerings</h4>
+    <div>
+      <p>The following course offerings that you are a student of already have exams set up. You can now view your own seat assignments and exam schedule. If you expect to see a course here but it is not here, your course staff have not yet set up exams for the course yet in this system. Contact your course staff.
+      </p>
+    </div>
     <ul class="mdl-list">
-    {% for offering in student_offerings %}
+    {% if student_offerings_existing == [] %}
+      <li class="mdl-list__item">
+        You are not a student in any course offerings with exams set up.
+      </li>
+    {% endif %}
+    {% for offering in student_offerings_existing %}
       <li class="mdl-list__item">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
          <a class="mdl-list__item-primary-content" href="{{ url_for('offering', offering=offering) }}">
@@ -27,8 +48,17 @@
     {% endfor %}
     </ul>
     <h4>Other Offerings</h4>
+    <div>
+    <p>In the following course offerings you are neither a staff member nor a student, but exams have been set up. You cannot do anything with these offerings.
+    </p>
+    </div>
     <ul class="mdl-list">
-    {% for offering in other_offerings %}
+    {% if other_offerings_existing == [] %}
+      <li class="mdl-list__item">
+        There are no other course offerings with exams set up.
+      </li>
+    {% endif %}
+    {% for offering in other_offerings_existing %}
       <li class="mdl-list__item">
         <span style="margin-right: 10px; color: #424242; font-weight: bold;"><small>{{ offering.start_at_date.strftime('%Y-%m') }}</small></span>
         {{ offering.name }}

--- a/server/templates/students.html.j2
+++ b/server/templates/students.html.j2
@@ -126,7 +126,9 @@
             <div class="material-icons" style="text-align: center; margin: 0; cursor: pointer;" onclick="location.href = '{{ url_for('edit_student', exam=exam, canvas_id=student.canvas_id) }}';" style="float: right;">edit</div>
           </td>
           <td class="mdl-data-table__cell--non-numeric" style="text-align: center;">
-            <div class="material-icons" style="text-align: center; margin: 0; cursor: pointer;" onclick="location.href = '{{ url_for('delete_student', exam=exam, canvas_id=student.canvas_id) }}';" style="float: right;">clear</div>
+            <div class="material-icons" style="text-align: center; margin: 0; cursor: pointer;" style="float: right;"
+            onclick="confirmAction('Are you sure you want to delete this student?', '{{ url_for('delete_student', exam=exam, canvas_id=student.canvas_id) }}');"
+            >clear</div>
           </td>
         </tr>
         {% endfor %}

--- a/server/views.py
+++ b/server/views.py
@@ -97,10 +97,14 @@ def add_offerings():
     staff_offerings_not_existing = [staff_offerings_id_to_model[canvas_id] for canvas_id in staff_offering_ids_not_existing]
     form = ChooseCourseOfferingForm(offering_list=staff_offerings_not_existing)
     if form.validate_on_submit():
+        to_be_saved = [staff_offerings_id_to_model[canvas_id] for canvas_id in form.offerings.data]
+        if not to_be_saved:
+            flash("No course offering imported.", 'info')
+            return redirect(url_for('offerings'))
         try:
-            to_be_saved = [staff_offerings_id_to_model[canvas_id] for canvas_id in form.offerings.data]
             db.session.bulk_save_objects(to_be_saved)
             db.session.commit()
+            flash(f"Imported {len(to_be_saved)} course offerings.", 'success')
             return redirect(url_for('offerings'))
         except Exception as e:
             db.session.rollback()

--- a/server/views.py
+++ b/server/views.py
@@ -88,7 +88,8 @@ def add_offerings():
     """
     user = canvas_client.get_user(current_user.canvas_id)
     staff_course_dics, _, _ = canvas_client.get_user_courses_categorized(user)
-    staff_offerings_id_to_model = {o.id: canvas_client.api_course_to_model(o) for o in staff_course_dics}
+    staff_offerings = [canvas_client.api_course_to_model(o) for o in staff_course_dics]
+    staff_offerings_id_to_model = {o.canvas_id: o for o in staff_offerings}
     staff_offering_ids_wanted = list(staff_offerings_id_to_model.keys())
     staff_offering_ids_existing = set([x[0] for x in Offering.query.filter(
         Offering.canvas_id.in_(staff_offering_ids_wanted)).with_entities(Offering.canvas_id)])


### PR DESCRIPTION
Previously we show all registered courses on front page.

Now, we only show courses that are initialized for the seating tool. Staff member can use the "add course" button to initialize their courses for the seating tool.

This declutters the front page.

Resolves #52 