### PR TITLE
Fix: Unhandled bug when batch deleting students by emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,4 @@ axe/
 gcp-service-account-credentials.json
 
 # bootstrap
-setup.sh
+setup*.sh

--- a/server/views.py
+++ b/server/views.py
@@ -630,7 +630,7 @@ def delete_students(exam):
         if not form.use_all_emails.data:
             emails = [x for x in str_set_to_set(form.emails.data) if x]
             students = Student.query.filter(
-                Student.email.in_(emails) & Student.exam_id == exam.id)
+                Student.email.in_(emails) & (Student.exam_id == exam.id))
         else:
             students = Student.query.filter_by(exam_id=exam.id)
         deleted = {student.email for student in students}


### PR DESCRIPTION
This one is actually funny.
We have  `students = Student.query.filter(Student.email.in_(emails) & Student.exam_id == exam.id)` and this works fine with Sqlite3.
But then for postgres you have to do `students = Student.query.filter(Student.email.in_(emails) & (Student.exam_id == exam.id))`. Otherwise the `&` get evaluated before `==`.