### PR TITLE
Feat: Set up logger & Fix: Fix Broken Link in Email Preview

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask, redirect
+import logging
 import flask.ctx
 from werkzeug.exceptions import HTTPException
 from canvasapi.exceptions import InvalidAccessToken
@@ -40,6 +41,12 @@ sentry_sdk.init(
 )
 
 app = App(__name__)
+
+
+if __name__ != '__main__':
+    # Only configure logging if running on a WSGI server, like gunicorn on Heroku
+    app.logger.addHandler(logging.StreamHandler())
+    app.logger.setLevel(logging.INFO)
 
 
 from config import ConfigBase, ProductionConfig, StagingConfig, DevelopmentConfig, TestingConfig  # noqa

--- a/server/controllers/health_controllers.py
+++ b/server/controllers/health_controllers.py
@@ -1,4 +1,4 @@
-from flask import jsonify
+from flask import jsonify, current_app
 
 from server.controllers import health_module
 
@@ -16,3 +16,12 @@ def check_db():
         return jsonify(status="UP"), 200
     except Exception as e:
         return jsonify(status="DOWN", error=str(e)), 500
+
+
+@health_module.route('/log')
+def check_logging():
+    current_app.logger.debug("Debug logging is working")
+    current_app.logger.info("Info logging is working")
+    current_app.logger.warning("Warning logging is working")
+    current_app.logger.error("Error logging is working")
+    return jsonify(status="SEE LOGS"), 200

--- a/server/services/email/smtp.py
+++ b/server/services/email/smtp.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from smtplib import SMTP, SMTPException
 from email.message import EmailMessage
 
@@ -47,6 +48,10 @@ def send_email(*, smtp: SMTPConfig, from_addr, to_addr, subject, body,
         server.quit()
         return (True, None)
     except SMTPException as e:
-        return (False, f"SMTP error occurred when sending email: {str(e)}\n Config: \n{smtp}")
+        err_msg = f"SMTP error occurred when sending email: {str(e)}\n Config: \n{smtp}"
+        current_app.logger.error(err_msg)
+        return (False, err_msg)
     except Exception as e:
-        return (False, f"Error sending email: {str(e)}\n Config: \n{smtp}")
+        err_msg = f"Error occurred when sending email: {str(e)}\n Config: \n{smtp}"
+        current_app.logger.error(err_msg)
+        return (False, err_msg)

--- a/server/services/email/templates/assignment_inform_email.html
+++ b/server/services/email/templates/assignment_inform_email.html
@@ -19,7 +19,7 @@
 
     <p>You can view this seat's position on the seating chart at:</p>
 
-    <p><a href="{{URL}}">View Seating Chart</a></p>
+    <p><a href="{{URL}}" class="preview-link">View Seating Chart</a></p>
 
     <p>
       If you have any questions or require further assistance, please do not

--- a/server/templates/email.html.j2
+++ b/server/templates/email.html.j2
@@ -59,6 +59,15 @@
       function updatePreview() {
           var htmlContent = document.getElementById('body').value;
           document.getElementById('preview').innerHTML = htmlContent;
+          document.querySelectorAll('.preview-link').forEach(link => {
+            const href = link.getAttribute('href');
+            if (!href || href.includes('{{URL}}')) {
+              link.addEventListener('click', function(e) {
+                e.preventDefault();
+                alert('This link would be clickable in a real email.');
+              });
+            }
+          });
       }
   </script>
 </main>


### PR DESCRIPTION
1) Adds proper logging for flask.

2) Previously, if we click on the "view seating chart" link on email preview we get an error because the href of that <a> is not plugged in yet. We now prevents that <a> tag from redirecting to fix this issue.